### PR TITLE
fix: enable mermaid diagrams in GitHub Pages

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -157,5 +157,38 @@ breakdown to issue <issue_summary.md>  -o <issue-dir>
 breakdown to task <issue.json>  -o <tasks-dir>
 ```
 
+# セットアップ
+以下の手順によって、使えるように準備します。
+
+1. 最初にDenoをセットアップします
+2. 次に CLI で使えるよう Deno installation を行います（推奨）
+   1. システムへインストールする
+   2. AI開発用のレポジトリにのみインストールする
+
+## CLI
+
+**まだ準備中**
+
+### 2-1. システムへインストールする
+
+```
+deno install --name=breakdown https://deno.land/x/breakdown.ts
+```
+
+### 2-2. AI開発用のレポジトリにのみインストールする
+
+```
+deno install --root ./tools --name=breakdown https://deno.land/x/breakdown.ts
+```
+
+もしインストールせずに使いたい場合は、以下のように実行できます。
+AI開発エージェントが利用する場合には冗長なので、PATHの通った場所へインストールすることをお勧めします。
+
+```
+deno run --allow-read --allow-net https://deno.land/x/my_tool.ts
+```
+
+
+
 # Documents
 https://tettuan.github.io/breakdown/

--- a/README.md
+++ b/README.md
@@ -154,5 +154,38 @@ breakdown to issue <issue_summary.md>  -o <issue-dir>
 breakdown to task <issue.json>  -o <tasks-dir>
 ```
 
+# Setup
+
+1. Set up Deno
+2. CLI Deno installation (recommended)
+   1. Install to system
+   2. Install to local AI agent project only
+
+## CLI
+
+**Not Prepared yet**
+
+### 2-1. Install to system
+
+```
+deno install --name=breakdown https://deno.land/x/breakdown.ts
+```
+
+### 2-2. Install to local AI agent project only
+
+```
+deno install --root ./tools --name=breakdown https://deno.land/x/breakdown.ts
+```
+
+If you prefer not to install, you can run it directly as follows.  
+However, it is recommended to place the executable in a directory included in your `PATH` for the AI agent to run it properly.
+
+```
+deno run --allow-read --allow-net https://deno.land/x/my_tool.ts
+```
+
+
+
+
 # Documents
 https://tettuan.github.io/breakdown/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,8 @@
+markdown: kramdown
+kramdown:
+  math_engine: mathjax
+  syntax_highlighter: rouge
+
+# Mermaid support
+mermaid:
+  version: "10.6.1"  # Pick the latest stable version 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <!-- Mermaid.js -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        mermaid.initialize({
+          startOnLoad: true,
+          theme: 'default',
+          securityLevel: 'loose'
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      {% if site.title and site.title != page.title %}
+      <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
+      {% endif %}
+
+      {{ content }}
+
+      {% if site.github.private != true and site.github.license %}
+      <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
+        This site is open source. {% github_edit_link "Improve this page" %}.
+      </div>
+      {% endif %}
+    </div>
+  </body>
+</html> 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ BreakDownは、MarkdownドキュメントをJSON形式に変換し、AIシステ
 
 ### 処理フロー
 
-```mermaid
+<div class="mermaid">
 sequenceDiagram
     participant Developer as アプリ開発者
     participant CursorCline as Cursor/Cline
@@ -37,13 +37,13 @@ sequenceDiagram
     CursorCline->>Developer: JSON指示書を取得
     Developer->>AI: JSON指示書をAI開発エージェントに送信
     AI->>AI: JSON指示書に基づき開発
-```
+</div>
 
 ## スキーマ定義
 
 プロジェクト、イシュー、タスクの関係は以下の通りです：
 
-```mermaid
+<div class="mermaid">
 erDiagram
   Project ||--|{ Issue : has
   Project {
@@ -79,7 +79,7 @@ erDiagram
     string command
     string DefinitionOfDone
   }
-```
+</div>
 
 ## タスクプロパティ
 
@@ -107,7 +107,7 @@ erDiagram
 
 ## タスクの状態遷移
 
-```mermaid
+<div class="mermaid">
 stateDiagram-v2
 direction LR
   state Result <<choice>>
@@ -121,7 +121,7 @@ direction LR
   Done --> [*]
   Error --> [*]
   Crash --> [*]
-```
+</div>
 
 ## ルール
 


### PR DESCRIPTION
- Add Jekyll configuration for mermaid support
- Create default layout with mermaid.js
- Update mermaid diagram syntax in index.md to use div tags