### PR TITLE
feat: unify CLI entry point to single path

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,8 +2,7 @@
   "name": "@tettuan/breakdown",
   "version": "1.1.1",
   "exports": {
-    ".": "./mod.ts",
-    "./cli": "./cli/breakdown.ts"
+    ".": "./mod.ts"
   },
   "bin": {
     "breakdown": "./cli/breakdown.ts"

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S deno run -A
 // This file intentionally omits module-level documentation (such as @module JSDoc)
 // to allow the README.md to be used as the "Overview" in JSR documentation.
 // See: https://jsr.io/docs/packages#documentation
@@ -9,3 +10,9 @@
 
 // Export only the CLI entry point
 export { runBreakdown } from "./cli/breakdown.ts";
+
+// When this file is executed directly (not imported as a module), redirect to CLI
+if (import.meta.main) {
+  const { runBreakdown } = await import("./cli/breakdown.ts");
+  await runBreakdown();
+}


### PR DESCRIPTION
## 概要

CLIエントリーポイントを統一し、ユーザーの混乱を防ぐための変更です。

## 変更内容

### 🔧 設定変更
- `deno.json` から `./cli` エクスポートを削除
- メインエントリーポイント (`.`) のみを保持

### 🚀 機能追加
- `mod.ts` に直接実行時のCLIリダイレクト機能を追加
- シェバン行追加でスクリプトとして実行可能

## 影響

### ✅ 動作する（推奨）
```bash
deno run --allow-read --allow-write --allow-env jsr:@tettuan/breakdown/ "--help"
```

### ❌ 動作しない（意図的に廃止）
```bash
deno run --allow-read --allow-write --allow-env jsr:@tettuan/breakdown/cli/ "--help"
```

## メリット

1. **統一されたエントリーポイント**: 1つの方法のみでアクセス
2. **ユーザー体験の向上**: 複数の起動方法による混乱を解消
3. **シンプルな構造**: 保守性とドキュメントの明確性向上

## テスト結果

- ✅ 全37個のテストが通過
- ✅ TypeScript型チェック通過
- ✅ JSR型チェック通過
- ✅ Lint・フォーマットチェック通過
- ✅ CI (deno task ci) 完全通過

## 後方互換性

- `bin` セクションの `breakdown` コマンドは維持
- ライブラリとしての `runBreakdown` エクスポートは維持
- 既存の機能に影響なし

## 実装詳細

### mod.ts の変更
- `#!/usr/bin/env -S deno run -A` シェバン行追加
- `import.meta.main` による直接実行検出
- CLI機能への自動リダイレクト

### deno.json の変更
- `exports` から `"./cli": "./cli/breakdown.ts"` を削除
- シンプルで明確なエクスポート構造
