### PR TITLE
fix: correct version to 1.2.1 to match JSR published version

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tettuan/breakdown",
-  "version": "1.2.4",
+  "version": "1.2.1",
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
## Summary
- Fix version in deno.json from 1.2.4 to 1.2.1 to match the published JSR version
- Address GitHub Actions test failures by ensuring version consistency

## Changes
- Updated `deno.json` version field to 1.2.1

## Test plan
- [x] Local CI passes completely (deno task ci)
- [x] All examples/* scripts execute successfully (19/19)
- [ ] GitHub Actions tests pass with corrected version

🤖 Generated with [Claude Code](https://claude.ai/code)