### PR TITLE
fix: Fix regex syntax error in version-check.yml

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
           VERSION_TS_CONTENT=$(cat lib/version.ts)
-          if [[ "$VERSION_TS_CONTENT" =~ export\ const\ VERSION\ =\ [\"\\']([^\"\\\']+)[\"\\'] ]]; then
+          if [[ "$VERSION_TS_CONTENT" =~ export\ const\ VERSION\ =\ [\"']([^\"']+)[\"'] ]]; then
             VERSION_TS_VERSION="${BASH_REMATCH[1]}"
             # Remove leading "v" if present
             VERSION_TS_VERSION=$(echo "$VERSION_TS_VERSION" | sed 's/^v//')


### PR DESCRIPTION
## Problem
GitHub Actions run #16868739443 failed due to a regex syntax error in version-check.yml.

## Root Cause
The regular expression in line 67 had excessive escaping in the character class:
```bash
["\\']([^"\\\']+)["\\']
```

This caused a bash syntax error: "unexpected token `)'".

## Solution
Simplified the regex by removing unnecessary escaping:
```bash
["']([^"']+)["']
```

## Testing
This fix resolves the syntax error and allows the version-check workflow to run successfully on release branches.

Fixes: https://github.com/tettuan/breakdown/actions/runs/16868739443